### PR TITLE
libtracefs: fix compiling with musl

### DIFF
--- a/include/tracefs-local.h
+++ b/include/tracefs-local.h
@@ -6,6 +6,8 @@
 #ifndef _TRACE_FS_LOCAL_H
 #define _TRACE_FS_LOCAL_H
 
+#include <pthread.h>
+
 #define __hidden __attribute__((visibility ("hidden")))
 #define __internal __attribute__((visibility ("internal")))
 #define __weak __attribute__((weak))


### PR DESCRIPTION
The library does not build with musl due to a missing pthread.h include.
This commit adds the missing include.

Fixes errors in the form of:

  In file included from tracefs-utils.c:21:
  ...cortex-a53_musl/libtracefs-1.4.1/include/tracefs-local.h:30:9:
    error: unknown type name 'pthread_mutex_t'
     30 |         pthread_mutex_t                 lock;
        |         ^~~~~~~~~~~~~~~
  .../cortex-a53_musl/libtracefs-1.4.1/include/tracefs-local.h:41:8:
    error: unknown type name 'pthread_mutex_t'
     41 | extern pthread_mutex_t toplevel_lock;
        |        ^~~~~~~~~~~~~~~
  ...cortex-a53_musl/libtracefs-1.4.1/include/tracefs-local.h:43:15:
    error: unknown type name 'pthread_mutex_t'
     43 | static inline pthread_mutex_t *trace_get_lock(struct ...
        |               ^~~~~~~~~~~~~~~

Signed-off-by: Nick Hainke <vincent@systemli.org>